### PR TITLE
[BUGFIX] Add coalescing operators

### DIFF
--- a/Classes/Domain/Transfer/CollectionInfo.php
+++ b/Classes/Domain/Transfer/CollectionInfo.php
@@ -131,10 +131,10 @@ class CollectionInfo
             ->execute()
             ->fetch();
 
-        $this->setDescription($properties['bm_image_gallery_description']);
-        $this->setLocation($properties['bm_image_gallery_location']);
+        $this->setDescription($properties['bm_image_gallery_description'] ?? '');
+        $this->setLocation($properties['bm_image_gallery_location'] ?? '');
 
-        if ($properties['bm_image_gallery_date'] > 0) {
+        if (($properties['bm_image_gallery_date'] ?? 0) > 0) {
             $this->setDate((new \DateTime())->setTimestamp($properties['bm_image_gallery_date']));
         }
     }


### PR DESCRIPTION
Null coalescing operators where added to prevent data from being 'null'.
This will prevent exceptional errors thrown due to data type mismatch.

Resolves: #23, #21